### PR TITLE
Fix LineLength property declaration

### DIFF
--- a/phpcs-standards/SmileLab/ruleset.xml
+++ b/phpcs-standards/SmileLab/ruleset.xml
@@ -4,13 +4,14 @@
     <description>Coding standard for SmileLab projects.</description>
     
     <rule ref="PSR2">
-        <exclude name="Generic.Files.LineLength"/>
         <exclude name="PSR2.Methods.MethodDeclaration"/>
     </rule>
     
     <rule ref="Generic.Files.LineLength">
-        <property name="lineLimit" value="135" />
-        <property name="absoluteLineLimit" value="135 "/>
+        <properties>
+            <property name="lineLimit" value="135" />
+            <property name="absoluteLineLimit" value="135 "/>
+        </properties>
     </rule>
     
     <rule ref="Generic.ControlStructures.InlineControlStructure" />


### PR DESCRIPTION
Currently the Generic.Files.LineLength is not correctly set in ruleset.xml, this commit fixes it so the rule is correctly enforced.